### PR TITLE
Fix up gzip error handling

### DIFF
--- a/src/dict2rest/gzip.go
+++ b/src/dict2rest/gzip.go
@@ -20,7 +20,9 @@ func (w gzipResponseWriter) Write(b []byte) (int, error) {
 func Gzip(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+			// If gzip is unsupported, revert to standard handler.
 			next.ServeHTTP(w, req)
+			return
 		}
 		w.Header().Set("Content-Encoding", "gzip")
 		gz := gzip.NewWriter(w)


### PR DESCRIPTION
In the case where the server has enabled gzip support but it is not
supported by the requesting client, the error path serves up the
uncompressed response but then fails to return immediately, resulting in
the compressed response being written out also.