### PR TITLE
Add support for deflate compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ The server binary has the following options:
 $ dict2rest --help
 
 Usage of dict2rest:
+  -deflate
+        Support DEFLATE compression
   -dicthost string
         Dict server name (default "localhost")
   -dictport string
         Dict server port (default "2628")
   -gzip
-        Enable gzip compression
+        Support gzip compression
   -port string
         Listen port (default "8080")
 ```

--- a/src/dict2rest/deflate.go
+++ b/src/dict2rest/deflate.go
@@ -24,12 +24,12 @@ func Deflate(next http.Handler) http.Handler {
 			next.ServeHTTP(w, req)
 			return
 		}
-		w.Header().Set("Content-Encoding", "deflate")
 		fl, err := flate.NewWriter(w, -1) // Use default compression level
 		if err != nil {
 			next.ServeHTTP(w, req)
 			return
 		}
+		w.Header().Set("Content-Encoding", "deflate")
 		defer fl.Close()
 		flw := flateResponseWriter{Writer: fl, ResponseWriter: w}
 		next.ServeHTTP(flw, req)

--- a/src/dict2rest/deflate.go
+++ b/src/dict2rest/deflate.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"compress/flate"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// DEFLATE Compression
+type flateResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w flateResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+func Deflate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !strings.Contains(req.Header.Get("Accept-Encoding"), "deflate") {
+			// If deflate is unsupported, revert to standard handler.
+			next.ServeHTTP(w, req)
+			return
+		}
+		w.Header().Set("Content-Encoding", "deflate")
+		fl, err := flate.NewWriter(w, -1) // Use default compression level
+		if err != nil {
+			next.ServeHTTP(w, req)
+			return
+		}
+		defer fl.Close()
+		flw := flateResponseWriter{Writer: fl, ResponseWriter: w}
+		next.ServeHTTP(flw, req)
+	})
+}


### PR DESCRIPTION
This enables optional support for deflate compression to be used for
HTTP requests. Primarily useful in cases where gzip compression is not
available on the requesting client side.