### PR TITLE
Inhibit repeated handling of requests through context-aware middleware chains

### DIFF
--- a/vendor/src/github.com/alexedwards/stack/.travis.yml
+++ b/vendor/src/github.com/alexedwards/stack/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: go
+go:
+  - 1.1
+  - 1.2
+  - 1.3
+  - 1.4
+  - tip

--- a/vendor/src/github.com/alexedwards/stack/LICENSE
+++ b/vendor/src/github.com/alexedwards/stack/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Alex Edwards
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/src/github.com/alexedwards/stack/README.md
+++ b/vendor/src/github.com/alexedwards/stack/README.md
@@ -1,0 +1,187 @@
+# Stack <br> [![Build Status](https://travis-ci.org/alexedwards/stack.svg?branch=master)](https://travis-ci.org/alexedwards/stack)  [![Coverage](http://gocover.io/_badge/github.com/alexedwards/stack?0)](http://gocover.io/github.com/alexedwards/stack)  [![GoDoc](http://godoc.org/github.com/alexedwards/stack?status.png)](http://godoc.org/github.com/alexedwards/stack)
+
+Stack provides an easy way to chain your HTTP middleware and handlers together and to pass request-scoped context between them. It's essentially a context-aware version of [Alice](https://github.com/justinas/alice).
+
+[Skip to the example &rsaquo;](#example)
+
+### Usage
+
+#### Making a chain
+
+Middleware chains are constructed with [`stack.New()`](http://godoc.org/github.com/alexedwards/stack#New):
+
+```go
+stack.New(middlewareOne, middlewareTwo, middlewareThree)
+```
+
+You can also store middleware chains as variables, and then [`Append()`](http://godoc.org/github.com/alexedwards/stack#Chain.Append) to them:
+
+```go
+stdStack := stack.New(middlewareOne, middlewareTwo)
+extStack := stdStack.Append(middlewareThree, middlewareFour)
+```
+
+Your middleware should have the signature `func(*stack.Context, http.Handler) http.Handler`. For example:
+
+```go
+func middlewareOne(ctx *stack.Context, next http.Handler) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // do something middleware-ish, accessing ctx
+    next.ServeHTTP(w, r)
+  })
+}
+```
+
+You can also use middleware with the signature `func(http.Handler) http.Handler` by adapting it with [`stack.Adapt()`](http://godoc.org/github.com/alexedwards/stack#Adapt). For example, if you had the middleware:
+
+```go
+func middlewareTwo(next http.Handler) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // do something else middleware-ish
+    next.ServeHTTP(w, r)
+  })
+}
+```
+
+You can add it to a chain like this:
+
+```go
+stack.New(middlewareOne, stack.Adapt(middlewareTwo), middlewareThree)
+```
+
+See the [codes samples](#code-samples) for real-life use of third-party middleware with Stack.
+
+#### Adding an application handler
+
+Application handlers should have the signature `func(*stack.Context, http.ResponseWriter, *http.Request)`. You add them to the end of a middleware chain with the [`Then()`](http://godoc.org/github.com/alexedwards/stack#Chain.Then) method. 
+
+So an application handler like this:
+
+```go
+func appHandler(ctx *stack.Context, w http.ResponseWriter, r *http.Request) {
+   // do something handler-ish, accessing ctx
+}
+```
+
+Is added to the end of a middleware chain like this:
+
+```go
+stack.New(middlewareOne, middlewareTwo).Then(appHandler)
+```
+
+For convenience [`ThenHandler()`](http://godoc.org/github.com/alexedwards/stack#Chain.ThenHandler) and [`ThenHandlerFunc()`](http://godoc.org/github.com/alexedwards/stack#Chain.ThenHandlerFunc) methods are also provided. These allow you to finish a chain with a standard `http.Handler` or `http.HandlerFunc` respectively.
+
+For example, you could use a standard `http.FileServer` as the application handler:
+
+```go
+fs :=  http.FileServer(http.Dir("./static/"))
+http.Handle("/", stack.New(middlewareOne, middlewareTwo).ThenHandler(fs))
+```
+
+Once a chain is 'closed' with any of these methods it is converted into a [`HandlerChain`](http://godoc.org/github.com/alexedwards/stack#HandlerChain) object which satisfies the `http.Handler` interface, and can be used with the `http.DefaultServeMux` and many other routers.
+
+#### Using context
+
+Request-scoped data (or *context*) can be passed through the chain by storing it in `stack.Context`. This is implemented as a pointer to a `map[string]interface{}` and scoped to the goroutine executing the current HTTP request. Operations on `stack.Context` are protected by a mutex, so if you need to pass the context pointer to another goroutine (say for logging or completing a background process) it is safe for concurrent use.
+
+Data is added with [`Context.Put()`](http://godoc.org/github.com/alexedwards/stack#Context.Put). The first parameter is a string (which acts as a key) and the second is the value you need to store. For example:
+
+```go
+func middlewareOne(ctx *stack.Context, next http.Handler) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    ctx.Put("token", "c9e452805dee5044ba520198628abcaa")
+    next.ServeHTTP(w, r)
+  })
+}
+```
+
+You retrieve data with [`Context.Get()`](http://godoc.org/github.com/alexedwards/stack#Context.Get). Remember to type assert the returned value into the type you're expecting.
+
+```go
+func appHandler(ctx *stack.Context, w http.ResponseWriter, r *http.Request) {
+  token, ok := ctx.Get("token").(string)
+  if !ok {
+    http.Error(w, http.StatusText(500), 500)
+    return
+  }
+  fmt.Fprintf(w, "Token is: %s", token)
+}
+```
+
+Note that `Context.Get()` will return `nil` if a key does not exist. If you need to tell the difference between a key having a `nil` value and it explicitly not existing, please check with [`Context.Exists()`](http://godoc.org/github.com/alexedwards/stack#Context.Exists).
+
+Keys (and their values) can be deleted with [`Context.Delete()`](http://godoc.org/github.com/alexedwards/stack#Context.Delete).    
+
+#### Injecting context
+
+It's possible to inject values into `stack.Context` during a request cycle but *before* the chain starts to be executed. This is useful if you need to inject parameters from a router into the context.
+
+The [`Inject()`](http://godoc.org/github.com/alexedwards/stack#Inject) function returns a new copy of the chain containing the injected context. You should make sure that you use this new copy &ndash; not the original &ndash; for subsequent processing.
+
+Here's an example of a wrapper for injecting [httprouter](https://github.com/julienschmidt/httprouter) params into the context:
+
+```go
+func InjectParams(hc stack.HandlerChain) httprouter.Handle {
+  return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+    newHandlerChain := stack.Inject(hc, "params", ps)
+    newHandlerChain.ServeHTTP(w, r)
+  }
+}
+```
+
+A full example is available in the [code samples](#code-samples).
+
+### Example
+
+```go
+package main
+
+import (
+  "net/http"
+  "github.com/alexedwards/stack"
+  "fmt"
+)
+
+func main() {
+  stk := stack.New(token, stack.Adapt(language))
+
+  http.Handle("/", stk.Then(final))
+
+  http.ListenAndServe(":3000", nil)
+}
+
+func token(ctx *stack.Context, next http.Handler) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    ctx.Put("token", "c9e452805dee5044ba520198628abcaa")
+    next.ServeHTTP(w, r)
+  })
+}
+
+func language(next http.Handler) http.Handler {
+  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Language", "en-gb")
+    next.ServeHTTP(w, r)
+  })
+}
+
+func final(ctx *stack.Context, w http.ResponseWriter, r *http.Request) {
+  token, ok := ctx.Get("token").(string)
+  if !ok {
+    http.Error(w, http.StatusText(500), 500)
+    return
+  }
+  fmt.Fprintf(w, "Token is: %s", token)
+}
+```
+
+### Code samples
+
+* [Integrating with httprouter](https://gist.github.com/alexedwards/4d20c505f389597c3360)
+* *More to follow*
+
+### TODO 
+
+- Add more code samples (using 3rd party middleware)
+- Make a `chain.Merge()` method
+- Mirror master in v1 branch (and mention gopkg.in in README)
+- Add benchmarks

--- a/vendor/src/github.com/alexedwards/stack/context.go
+++ b/vendor/src/github.com/alexedwards/stack/context.go
@@ -1,0 +1,55 @@
+package stack
+
+import (
+	"sync"
+)
+
+type Context struct {
+	mu sync.RWMutex
+	m  map[string]interface{}
+}
+
+func NewContext() *Context {
+	m := make(map[string]interface{})
+	return &Context{m: m}
+}
+
+func (c *Context) Get(key string) interface{} {
+	if !c.Exists(key) {
+		return nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.m[key]
+}
+
+func (c *Context) Put(key string, val interface{}) *Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[key] = val
+	return c
+}
+
+func (c *Context) Delete(key string) *Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.m, key)
+	return c
+}
+
+func (c *Context) Exists(key string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.m[key]
+	return ok
+}
+
+func (c *Context) copy() *Context {
+	nc := NewContext()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for k, v := range c.m {
+		nc.m[k] = v
+	}
+	return nc
+}

--- a/vendor/src/github.com/alexedwards/stack/context_test.go
+++ b/vendor/src/github.com/alexedwards/stack/context_test.go
@@ -1,0 +1,48 @@
+package stack
+
+import "testing"
+
+func TestGet(t *testing.T) {
+	ctx := NewContext()
+	ctx.m["flip"] = "flop"
+	ctx.m["bish"] = nil
+
+	val := ctx.Get("flip")
+	assertEquals(t, "flop", val)
+
+	val = ctx.Get("bish")
+	assertEquals(t, nil, val)
+}
+
+func TestPut(t *testing.T) {
+	ctx := NewContext()
+
+	ctx.Put("bish", "bash")
+	assertEquals(t, "bash", ctx.m["bish"])
+}
+
+func TestDelete(t *testing.T) {
+	ctx := NewContext()
+	ctx.m["flip"] = "flop"
+
+	ctx.Delete("flip")
+	assertEquals(t, nil, ctx.m["flip"])
+}
+
+func TestCopy(t *testing.T) {
+	ctx := NewContext()
+	ctx.m["flip"] = "flop"
+
+	ctx2 := ctx.copy()
+	ctx2.m["bish"] = "bash"
+	assertEquals(t, nil, ctx.m["bish"])
+	assertEquals(t, "bash", ctx2.m["bish"])
+}
+
+func TestExists(t *testing.T) {
+	ctx := NewContext()
+	ctx.m["flip"] = "flop"
+
+	assertEquals(t, true, ctx.Exists("flip"))
+	assertEquals(t, false, ctx.Exists("bash"))
+}

--- a/vendor/src/github.com/alexedwards/stack/stack.go
+++ b/vendor/src/github.com/alexedwards/stack/stack.go
@@ -1,0 +1,94 @@
+package stack
+
+import "net/http"
+
+type chainHandler func(*Context) http.Handler
+type chainMiddleware func(*Context, http.Handler) http.Handler
+
+type Chain struct {
+	mws []chainMiddleware
+	h   chainHandler
+}
+
+func New(mws ...chainMiddleware) Chain {
+	return Chain{mws: mws}
+}
+
+func (c Chain) Append(mws ...chainMiddleware) Chain {
+	newMws := make([]chainMiddleware, len(c.mws)+len(mws))
+	copy(newMws[:len(c.mws)], c.mws)
+	copy(newMws[len(c.mws):], mws)
+	c.mws = newMws
+	return c
+}
+
+func (c Chain) Then(chf func(ctx *Context, w http.ResponseWriter, r *http.Request)) HandlerChain {
+	c.h = adaptContextHandlerFunc(chf)
+	return newHandlerChain(c)
+}
+
+func (c Chain) ThenHandler(h http.Handler) HandlerChain {
+	c.h = adaptHandler(h)
+	return newHandlerChain(c)
+}
+
+func (c Chain) ThenHandlerFunc(fn func(http.ResponseWriter, *http.Request)) HandlerChain {
+	c.h = adaptHandlerFunc(fn)
+	return newHandlerChain(c)
+}
+
+type HandlerChain struct {
+	context *Context
+	Chain
+}
+
+func newHandlerChain(c Chain) HandlerChain {
+	return HandlerChain{context: NewContext(), Chain: c}
+}
+
+func (hc HandlerChain) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Always take a copy of context (i.e. pointing to a brand new memory location)
+	ctx := hc.context.copy()
+
+	final := hc.h(ctx)
+	for i := len(hc.mws) - 1; i >= 0; i-- {
+		final = hc.mws[i](ctx, final)
+	}
+	final.ServeHTTP(w, r)
+}
+
+func Inject(hc HandlerChain, key string, val interface{}) HandlerChain {
+	hc.context = hc.context.copy().Put(key, val)
+	return hc
+}
+
+// Adapt third party middleware with the signature
+// func(http.Handler) http.Handler into chainMiddleware
+func Adapt(fn func(http.Handler) http.Handler) chainMiddleware {
+	return func(ctx *Context, h http.Handler) http.Handler {
+		return fn(h)
+	}
+}
+
+// Adapt http.Handler into a chainHandler
+func adaptHandler(h http.Handler) chainHandler {
+	return func(ctx *Context) http.Handler {
+		return h
+	}
+}
+
+// Adapt a function with the signature
+// func(http.ResponseWriter, *http.Request) into a chainHandler
+func adaptHandlerFunc(fn func(w http.ResponseWriter, r *http.Request)) chainHandler {
+	return adaptHandler(http.HandlerFunc(fn))
+}
+
+// Adapt a function with the signature
+// func(Context, http.ResponseWriter, *http.Request) into a chainHandler
+func adaptContextHandlerFunc(fn func(ctx *Context, w http.ResponseWriter, r *http.Request)) chainHandler {
+	return func(ctx *Context) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fn(ctx, w, r)
+		})
+	}
+}

--- a/vendor/src/github.com/alexedwards/stack/stack_test.go
+++ b/vendor/src/github.com/alexedwards/stack/stack_test.go
@@ -1,0 +1,126 @@
+package stack
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func assertEquals(t *testing.T, e interface{}, o interface{}) {
+	if e != o {
+		t.Errorf("\n...expected = %v\n...obtained = %v", e, o)
+	}
+}
+
+func serveAndRequest(h http.Handler) string {
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+	res, err := http.Get(ts.URL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	resBody, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return string(resBody)
+}
+
+func bishMiddleware(ctx *Context, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx.Put("bish", "bash")
+		fmt.Fprintf(w, "bishMiddleware>")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func flipMiddleware(ctx *Context, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "flipMiddleware>")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func wobbleMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "wobbleMiddleware>")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func bishHandler(ctx *Context, w http.ResponseWriter, r *http.Request) {
+	val := ctx.Get("bish")
+	fmt.Fprintf(w, "bishHandler [bish=%v]", val)
+}
+
+func flipHandler(ctx *Context, w http.ResponseWriter, r *http.Request) {
+	valb := ctx.Get("bish")
+	valf := ctx.Get("flip")
+	fmt.Fprintf(w, "flipHandler [bish=%v,flip=%v]", valb, valf)
+}
+
+func TestNew(t *testing.T) {
+	st := New(bishMiddleware, flipMiddleware).Then(bishHandler)
+	res := serveAndRequest(st)
+	assertEquals(t, "bishMiddleware>flipMiddleware>bishHandler [bish=bash]", res)
+}
+
+func TestAppend(t *testing.T) {
+	st := New(bishMiddleware).Append(flipMiddleware, flipMiddleware).Then(bishHandler)
+	res := serveAndRequest(st)
+	assertEquals(t, "bishMiddleware>flipMiddleware>flipMiddleware>bishHandler [bish=bash]", res)
+}
+
+func TestAppendDoesNotMutate(t *testing.T) {
+	st1 := New(bishMiddleware, flipMiddleware)
+	st2 := st1.Append(flipMiddleware, flipMiddleware)
+	res := serveAndRequest(st1.Then(bishHandler))
+	assertEquals(t, "bishMiddleware>flipMiddleware>bishHandler [bish=bash]", res)
+	res = serveAndRequest(st2.Then(bishHandler))
+	assertEquals(t, "bishMiddleware>flipMiddleware>flipMiddleware>flipMiddleware>bishHandler [bish=bash]", res)
+}
+
+func TestThen(t *testing.T) {
+	chf := func(ctx *Context, w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "An anonymous ContextHandlerFunc")
+	}
+	st := New().Then(chf)
+	res := serveAndRequest(st)
+	assertEquals(t, "An anonymous ContextHandlerFunc", res)
+}
+
+func TestThenHandler(t *testing.T) {
+	st := New().ThenHandler(http.NotFoundHandler())
+	res := serveAndRequest(st)
+	assertEquals(t, "404 page not found\n", res)
+}
+
+func TestThenHandlerFunc(t *testing.T) {
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "An anonymous HandlerFunc")
+	}
+	st := New().ThenHandlerFunc(hf)
+	res := serveAndRequest(st)
+	assertEquals(t, "An anonymous HandlerFunc", res)
+}
+
+func TestMixedMiddleware(t *testing.T) {
+	st := New(bishMiddleware, Adapt(wobbleMiddleware), flipMiddleware).Then(bishHandler)
+	res := serveAndRequest(st)
+	assertEquals(t, "bishMiddleware>wobbleMiddleware>flipMiddleware>bishHandler [bish=bash]", res)
+}
+
+func TestInject(t *testing.T) {
+	st := New(flipMiddleware).Then(flipHandler)
+	st2 := Inject(st, "bish", "boop")
+
+	res := serveAndRequest(st2)
+	assertEquals(t, "flipMiddleware>flipHandler [bish=boop,flip=<nil>]", res)
+
+	res = serveAndRequest(st)
+	assertEquals(t, "flipMiddleware>flipHandler [bish=<nil>,flip=<nil>]", res)
+}


### PR DESCRIPTION
Presently the handler chain requires each handler to advance to the next handler in order to make it to the router, with each successive middleware being unable to determine whether the previous one has already handled the request or not. This was a particular issue when enabling support for multiple compressors in parallel. While I'm not sure what the best way to address this in Go would be, I've attempted to work around this by passing along context from the preceeding handler to indicate whether the request has been handled or not and we simply need to keep walking the chain. While this now works for my test cases, there's likely a far less clunky solution for this problem.